### PR TITLE
Agrupamento de mensagens de erro do ElasticSearch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile*
+docker-compose*.yml

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,11 @@
+FROM ruby:2.3.3
+RUN gem install bundler
+RUN bundle config git.allow_insecure true
+
+RUN mkdir /app
+WORKDIR /app
+ADD . /app/
+RUN bundle install --jobs 20 --retry 5
+
+ENTRYPOINT []
+# CMD ["bundle", "exec", "rspec"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "2"
+services:
+  chewy:
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    command: bash
+    volumes:
+      - .:/app
+    environment:
+      - TERM=xterm-256color
+      - ELASTICSEARCH_URL=http://elasticsearch:9200
+      # - BYEBUG_DEBUG=true
+    # stdin_open: true
+    # tty: true
+    links:
+      - elasticsearch
+
+  elasticsearch:
+    image: elasticsearch:2.4.1
+    expose:
+      - "9200"

--- a/lib/chewy/errors.rb
+++ b/lib/chewy/errors.rb
@@ -29,11 +29,29 @@ Please wrap your code with `Chewy.strategy(:strategy_name) block.`
       errors.each do |action, errors|
         message << "    #{action.to_s.humanize} errors:\n"
         errors.each do |error, documents|
-          message << "      `#{error}`\n"
-          message << "        on #{documents.count} documents: #{documents}\n"
+          anonymous_error = anonymize_with_placeholders(error)
+          anonymous_documents = ['?']
+          message << "      `#{anonymous_error}`\n"
+          message << "        on #{anonymous_documents.count} documents: #{anonymous_documents}\n"
         end
       end
       super message
+    end
+
+    # Replace IDs and other specific data for placeholder '?'
+    # to anonymize the error and make it easier to group in the exception tracker
+    #
+    # Example input:
+    #   rejected execution of org.elasticsearch...Service$4@553f9b39 on EsThreadPoolExecutor[
+    #     ...capacity = 50, org.elasticsearch...EsThreadPoolExecutor@2134b86a[
+    #       ...pool size = 2, active threads = 2, queued tasks = 50, completed tasks = 6635921]]
+    #
+    # Example output:
+    #   rejected execution of org.elasticsearch...Service$? on EsThreadPoolExecutor[
+    #     ...capacity = ?, org.elasticsearch...EsThreadPoolExecutor@?[
+    #       ...pool size = 2, active threads = 2, queued tasks = ?, completed tasks = ?]]
+    def anonymize_with_placeholders(input)
+      input.to_s.gsub(/\b\d[@\w]+\b/, '?')
     end
   end
 

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -367,7 +367,11 @@ describe Chewy::Type::Import do
         end
       end
 
-      specify { expect { city.import!(dummy_cities) }.to raise_error Chewy::ImportFailed }
+      # Error message with placeholder '?'
+      specify do
+        expect { city.import!(dummy_cities) }.
+          to raise_error Chewy::ImportFailed, /\bparse\s+field\b.+\bname\b.+\?/m
+      end
     end
 
     context 'when .import fails' do


### PR DESCRIPTION
Isto resolve uma parte de https://github.com/b2beauty/beautydate/issues/1506

As mensagens não estavam sendo agrupadas porque na exception há vários parâmetros específicos de cada chamada. Assim, esta PR substitui esses parâmetros por um placeholder `?` pra que o gerenciador de exceptions possa juntá-las automaticamente.

![screen shot 2017-01-05 at 11 21 58](https://cloud.githubusercontent.com/assets/3451581/21682599/ad258578-d33c-11e6-849a-396f857c5780.png)
